### PR TITLE
Update Parlot

### DIFF
--- a/src/Hyperbee.XS.Extensions/Hyperbee.Xs.Extensions.csproj
+++ b/src/Hyperbee.XS.Extensions/Hyperbee.Xs.Extensions.csproj
@@ -44,7 +44,7 @@
     <PackageReference Include="Hyperbee.Collections" Version="2.3.0" />
     <PackageReference Include="Hyperbee.Expressions" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-    <PackageReference Include="Parlot" Version="1.3.2" />
+    <PackageReference Include="Parlot" Version="1.3.3" />
     <ProjectReference Include="..\Hyperbee.XS\Hyperbee.XS.csproj" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Hyperbee.XS/Hyperbee.XS.csproj
+++ b/src/Hyperbee.XS/Hyperbee.XS.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="NuGet.Packaging" Version="6.12.1" />
     <PackageReference Include="NuGet.ProjectModel" Version="6.12.1" />
     <PackageReference Include="NuGet.Protocol" Version="6.12.1" />
-    <PackageReference Include="Parlot" Version="1.3.2" />
+    <PackageReference Include="Parlot" Version="1.3.3" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Currently used version has a performance issue by creating too many strings to represent the textual format of the parser. This version fixes it (creates the string only on demand).