### PR TITLE
Release v1.3.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>3</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <RevisionVersion>0</RevisionVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <FileVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion).$(RevisionVersion)</FileVersion>

--- a/samples/extensions.dib
+++ b/samples/extensions.dib
@@ -1,6 +1,6 @@
 #!meta
 
-{"kernelInfo":{"defaultKernelName":"csharp","items":[{"aliases":[],"languageName":"csharp","name":"csharp"},{"aliases":[],"name":"razor"},{"aliases":[],"name":"xs"},{"aliases":[],"name":"xs-show"}]}}
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","languageName":"csharp"},{"name":"razor"},{"name":"xs"},{"name":"xs-show"},{"name":"fsharp","languageName":"F#","aliases":["f#","fs"]},{"name":"html","languageName":"HTML"},{"name":"http","languageName":"HTTP"},{"name":"javascript","languageName":"JavaScript","aliases":["js"]},{"name":"mermaid","languageName":"Mermaid"},{"name":"pwsh","languageName":"PowerShell","aliases":["powershell"]},{"name":"value"}]}}
 
 #!pwsh
 

--- a/src/Hyperbee.XS/Core/Parsers/RawStringParser.cs
+++ b/src/Hyperbee.XS/Core/Parsers/RawStringParser.cs
@@ -1,0 +1,103 @@
+﻿using Parlot;
+using Parlot.Fluent;
+
+namespace Hyperbee.XS.Core.Parsers;
+
+public class RawStringParser : Parser<TextSpan>
+{
+    private enum ParserState
+    {
+        Initial,
+        BeginContent,
+        Content,
+        EndContent
+    }
+
+    public override bool Parse( ParseContext context, ref ParseResult<TextSpan> result )
+    {
+        context.EnterParser( this );
+
+        var scanner = context.Scanner;
+        var cursor = scanner.Cursor;
+        var start = cursor.Position;
+        TextPosition begin = default;
+
+        scanner.SkipWhiteSpaceOrNewLine();
+
+        var state = ParserState.Initial;
+        var quoteCount = 0;
+        var requiredQuoteCount = 0;
+
+        while ( true )
+        {
+            var current = cursor.Current;
+
+            switch ( state )
+            {
+                case ParserState.Initial:
+                    if ( current == '"' )
+                    {
+                        quoteCount++;
+                    }
+                    else if ( quoteCount >= 3 )
+                    {
+                        state = ParserState.BeginContent;
+                        requiredQuoteCount = quoteCount;
+                        begin = scanner.Cursor.Position;
+                    }
+                    else
+                    {
+                        scanner.Cursor.ResetPosition( start );
+                        context.ExitParser( this );
+                        return false;
+                    }
+                    break;
+
+                case ParserState.BeginContent:
+                    state = ParserState.Content;
+                    quoteCount = 0;
+                    break;
+
+                case ParserState.Content:
+                    if ( current == '"' )
+                    {
+                        quoteCount++;
+                        if ( quoteCount == requiredQuoteCount )
+                        {
+                            state = ParserState.EndContent;
+                        }
+                    }
+                    else
+                    {
+                        quoteCount = 0;
+                    }
+                    break;
+
+                case ParserState.EndContent:
+                    var end = scanner.Cursor.Position.Offset;
+
+                    var decoded = Character.DecodeString(
+                        new TextSpan( scanner.Buffer, begin.Offset, end - begin.Offset - requiredQuoteCount )
+                    );
+
+                    result.Set( start.Offset, end, decoded );
+                    context.ExitParser( this );
+                    cursor.Advance();
+
+                    return true;
+
+                default:
+                    throw new ParseException( $"Invalid state for {nameof( RawStringParser )} found.", start );
+            }
+
+            cursor.Advance();
+
+            if ( !cursor.Eof )
+                continue;
+
+            scanner.Cursor.ResetPosition( start );
+            context.ExitParser( this );
+            return false;
+        }
+    }
+}

--- a/src/Hyperbee.XS/Core/Parsers/TerminationParser.cs
+++ b/src/Hyperbee.XS/Core/Parsers/TerminationParser.cs
@@ -19,8 +19,8 @@ public static partial class XsParsers
     {
         return parser.AndSkipIf(
             ( ctx, _ ) => ((XsContext) ctx).RequireTermination,
-            OneOrMany( Terms.Char( ';' ) ),
-            ZeroOrMany( Terms.Char( ';' ) ).RequireTermination( true )
+            OneOrMany( Terms.Char( ';' ) ).ElseError( XsParser.InvalidTerminationMessage ),
+            ZeroOrMany( Terms.Char( ';' ) ).RequireTermination( true ).ElseError( XsParser.InvalidTerminationMessage )
         ).Named( "Termination" );
     }
 }

--- a/src/Hyperbee.XS/Core/Parsers/TypeRuntimeParser.cs
+++ b/src/Hyperbee.XS/Core/Parsers/TypeRuntimeParser.cs
@@ -51,6 +51,14 @@ internal class TypeRuntimeParser : Parser<Type>
             scanner.SkipWhiteSpaceOrNewLine();
         }
 
+        if ( scanner.Cursor.Current == ':' )
+        {
+            // Invalid for types to end with a colon (Identifier is being used as a label)
+            cursor.ResetPosition( start );
+            context.ExitParser( this );
+            return false;
+        }
+
         // get any generic argument types
 
         var genericArgs = new List<Type>();

--- a/src/Hyperbee.XS/Core/TypeResolver.cs
+++ b/src/Hyperbee.XS/Core/TypeResolver.cs
@@ -2,7 +2,6 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Xml.Linq;
 using Hyperbee.Collections;
 
 namespace Hyperbee.XS.Core;
@@ -12,6 +11,8 @@ public interface ITypeResolver
     Type ResolveType( string typeName );
     MethodInfo ResolveMethod( Type type, string methodName, IReadOnlyList<Type> typeArgs, IReadOnlyList<Expression> args );
     MemberInfo ResolveMember( Type type, string memberName );
+    Expression ResolveIndexerExpression( Expression targetExpression, IReadOnlyList<Expression> indexes );
+    Expression ResolveMemberExpression( Expression targetExpression, string name, IReadOnlyList<Type> typeArgs, IReadOnlyList<Expression> args );
 }
 
 public class TypeResolver : ITypeResolver
@@ -165,6 +166,100 @@ public class TypeResolver : ITypeResolver
     {
         const BindingFlags BindingAttr = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
         return type.GetMember( memberName, BindingAttr ).FirstOrDefault();
+    }
+
+    public virtual Expression ResolveIndexerExpression( Expression targetExpression, IReadOnlyList<Expression> indexes )
+    {
+        var indexers = targetExpression.Type.GetProperties()
+            .Where( p => p.GetIndexParameters().Length == indexes.Count )
+            .ToArray();
+
+        if ( indexers.Length == 0 )
+            return Expression.ArrayAccess( targetExpression, indexes );
+
+        // Find the best match based on parameter types
+        var indexer = indexers.FirstOrDefault( p =>
+            p.GetIndexParameters()
+                .Select( param => param.ParameterType )
+                .SequenceEqual( indexes.Select( i => i.Type ) ) );
+
+        if ( indexer == null )
+        {
+            throw new InvalidOperationException(
+                $"No matching indexer found on type '{targetExpression.Type}' with parameter types: " +
+                $"{string.Join( ", ", indexes.Select( i => i.Type.Name ) )}." );
+        }
+
+        return Expression.Property( targetExpression, indexer, indexes.ToArray() );
+    }
+
+    public virtual Expression ResolveMemberExpression( Expression targetExpression, string name, IReadOnlyList<Type> typeArgs, IReadOnlyList<Expression> args )
+    {
+        var type = TypeOf( targetExpression );
+
+        // method
+
+        if ( args != null )
+        {
+            var method = ResolveMethod( type, name, typeArgs, args );
+
+            if ( method == null )
+                throw new InvalidOperationException( $"Method '{name}' not found on type '{type}'." );
+
+            var arguments = GetArgumentsWithDefaults( method, targetExpression, args );
+
+            return method.IsStatic
+                ? Expression.Call( method, arguments )
+                : Expression.Call( targetExpression, method, arguments );
+        }
+
+        // property or field
+
+        var member = ResolveMember( type, name );
+
+        if ( member == null )
+            throw new InvalidOperationException( $"Member '{name}' not found on type '{type}'." );
+
+        return member switch
+        {
+            PropertyInfo property => Expression.Property( targetExpression, property ),
+            FieldInfo field => Expression.Field( targetExpression, field ),
+            _ => throw new InvalidOperationException( $"Member '{name}' is not a property or field." )
+        };
+
+        static IReadOnlyList<Expression> GetArgumentsWithDefaults( MethodInfo method, Expression targetExpression, IReadOnlyList<Expression> providedArgs )
+        {
+            var parameters = method.GetParameters();
+            var isExtension = method.IsDefined( typeof( ExtensionAttribute ), false );
+
+            var providedOffset = isExtension ? 1 : 0;
+            var providedCount = providedArgs.Count;
+            var totalParameters = parameters.Length;
+
+            if ( providedCount == totalParameters )
+                return providedArgs;
+
+            var methodArgs = new Expression[totalParameters];
+
+            // add provided arguments
+            if ( isExtension )
+                methodArgs[0] = targetExpression;
+
+            for ( var i = 0; i < providedCount; i++ )
+            {
+                methodArgs[i + providedOffset] = providedArgs[i];
+            }
+
+            // add missing optional parameters
+            for ( var i = providedCount + providedOffset; i < totalParameters; i++ )
+            {
+                methodArgs[i] = parameters[i].HasDefaultValue
+                    ? Expression.Constant( parameters[i].DefaultValue, parameters[i].ParameterType )
+                    : throw new ArgumentException( $"Missing required parameter: {parameters[i].Name}" );
+            }
+
+            return methodArgs;
+        }
     }
 
     public void RegisterExtensionMethods( IEnumerable<Assembly> assemblies )
@@ -400,5 +495,18 @@ public class TypeResolver : ITypeResolver
 
         return p1.Length.CompareTo( p2.Length );
     }
+
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    private static Type TypeOf( Expression expression )
+    {
+        ArgumentNullException.ThrowIfNull( expression, nameof( expression ) );
+
+        return expression switch
+        {
+            ConstantExpression ce => ce.Value as Type ?? ce.Type,
+            _ => expression.Type
+        };
+    }
+
 }
 

--- a/src/Hyperbee.XS/Core/TypeResolver.cs
+++ b/src/Hyperbee.XS/Core/TypeResolver.cs
@@ -11,11 +11,14 @@ public interface ITypeResolver
     Type ResolveType( string typeName );
     MethodInfo ResolveMethod( Type type, string methodName, IReadOnlyList<Type> typeArgs, IReadOnlyList<Expression> args );
     MemberInfo ResolveMember( Type type, string memberName );
-    Expression ResolveIndexerExpression( Expression targetExpression, IReadOnlyList<Expression> indexes );
-    Expression ResolveMemberExpression( Expression targetExpression, string name, IReadOnlyList<Type> typeArgs, IReadOnlyList<Expression> args );
+}
+public interface ITypeRewriter
+{
+    Expression RewriteIndexerExpression( Expression targetExpression, IReadOnlyList<Expression> indexes );
+    Expression RewriteMemberExpression( Expression targetExpression, string name, IReadOnlyList<Type> typeArgs, IReadOnlyList<Expression> args );
 }
 
-public class TypeResolver : ITypeResolver
+public class TypeResolver : ITypeResolver, ITypeRewriter
 {
     public ReferenceManager ReferenceManager { get; }
 
@@ -168,7 +171,7 @@ public class TypeResolver : ITypeResolver
         return type.GetMember( memberName, BindingAttr ).FirstOrDefault();
     }
 
-    public virtual Expression ResolveIndexerExpression( Expression targetExpression, IReadOnlyList<Expression> indexes )
+    public virtual Expression RewriteIndexerExpression( Expression targetExpression, IReadOnlyList<Expression> indexes )
     {
         var indexers = targetExpression.Type.GetProperties()
             .Where( p => p.GetIndexParameters().Length == indexes.Count )
@@ -193,7 +196,7 @@ public class TypeResolver : ITypeResolver
         return Expression.Property( targetExpression, indexer, indexes.ToArray() );
     }
 
-    public virtual Expression ResolveMemberExpression( Expression targetExpression, string name, IReadOnlyList<Type> typeArgs, IReadOnlyList<Expression> args )
+    public virtual Expression RewriteMemberExpression( Expression targetExpression, string name, IReadOnlyList<Type> typeArgs, IReadOnlyList<Expression> args )
     {
         var type = TypeOf( targetExpression );
 

--- a/src/Hyperbee.XS/SyntaxException.cs
+++ b/src/Hyperbee.XS/SyntaxException.cs
@@ -30,7 +30,7 @@ public class SyntaxException : Exception
             var sourceLine = BufferHelper.GetLine( Buffer, Offset, out var caret );
             var caretLine = new string( ' ', caret ) + "^";
 
-            return $"({Line} {Column})\n{sourceLine}\n{caretLine}";
+            return $"{base.Message}\n({Line} {Column})\n{sourceLine}\n{caretLine}";
         }
     }
 }

--- a/src/Hyperbee.XS/XsParser.Identifiers.cs
+++ b/src/Hyperbee.XS/XsParser.Identifiers.cs
@@ -8,6 +8,7 @@ namespace Hyperbee.XS;
 public partial class XsParser
 {
     public const string InvalidSyntaxMessage = "Invalid syntax.";
+    public const string InvalidTerminationMessage = "Invalid termination, missing ';'.";
     public const string InvalidTypeMessage = "Invalid type.";
     public const string InvalidExpressionMessage = "Invalid expression.";
     public const string InvalidStatementMessage = "Invalid statement.";
@@ -21,7 +22,7 @@ public partial class XsParser
     internal static Parser<char> CloseBracket = Terms.Char( ']' ).ElseError( InvalidSyntaxMessage );
     internal static Parser<char> Assignment = Terms.Char( '=' ).ElseError( InvalidSyntaxMessage );
     internal static Parser<char> Delimiter = Terms.Char( ',' ).ElseError( InvalidSyntaxMessage );
-    internal static Parser<char> Terminator = Terms.Char( ';' ).ElseError( InvalidSyntaxMessage );
+    internal static Parser<char> Terminator = Terms.Char( ';' ).ElseError( InvalidTerminationMessage );
     internal static Parser<char> Colon = Terms.Char( ':' ).ElseError( InvalidSyntaxMessage );
 }
 

--- a/src/Hyperbee.XS/XsParser.Literals.cs
+++ b/src/Hyperbee.XS/XsParser.Literals.cs
@@ -35,6 +35,9 @@ public partial class XsParser
         var stringLiteral = Terms.String( StringLiteralQuotes.Double )
             .Then<Expression>( static value => Constant( value.ToString() ) );
 
+        var rawStringLiteral = new RawStringParser().
+            Then<Expression>( static value => Constant( value.ToString() ) );
+
         var nullLiteral = Terms.Text( "null" )
             .Then<Expression>( static _ => Constant( null ) );
 
@@ -43,6 +46,7 @@ public partial class XsParser
             doubleLiteral,
             floatLiteral,
             integerLiteral,
+            rawStringLiteral,
             characterLiteral,
             stringLiteral,
             booleanLiteral,

--- a/src/Hyperbee.XS/XsParser.Members.cs
+++ b/src/Hyperbee.XS/XsParser.Members.cs
@@ -23,7 +23,7 @@ public partial class XsParser
             {
                 var (_, resolver) = ctx;
 
-                return resolver.ResolveIndexerExpression( targetExpression, indexes );
+                return resolver.RewriteIndexerExpression( targetExpression, indexes );
             }
         );
     }
@@ -43,10 +43,12 @@ public partial class XsParser
                             )
                         )
                         .And(
-                            Between(
-                                Terms.Char( '(' ),
-                                ArgsParser( expression ),
-                                Terms.Char( ')' )
+                            ZeroOrOne(
+                                Between(
+                                    Terms.Char( '(' ),
+                                    ArgsParser( expression ),
+                                    Terms.Char( ')' )
+                                )
                             )
                         )
                     )
@@ -60,7 +62,7 @@ public partial class XsParser
 
                 var (_, resolver) = ctx;
 
-                return resolver.ResolveMemberExpression( targetExpression, name, typeArgs, args );
+                return resolver.RewriteMemberExpression( targetExpression, name, typeArgs, args );
             } );
     }
 }

--- a/src/Hyperbee.XS/XsParser.Members.cs
+++ b/src/Hyperbee.XS/XsParser.Members.cs
@@ -19,31 +19,11 @@ public partial class XsParser
                     CloseBracket
                 )
             )
-            .Then<Expression>( indexes =>
+            .Then( (ctx, indexes) =>
             {
-                var indexers = targetExpression.Type.GetProperties()
-                    .Where( p => p.GetIndexParameters().Length == indexes.Count )
-                    .ToArray();
+                var (_, resolver) = ctx;
 
-                if ( indexers.Length != 0 )
-                {
-                    // Find the best match based on parameter types
-                    var indexer = indexers.FirstOrDefault( p =>
-                        p.GetIndexParameters()
-                            .Select( param => param.ParameterType )
-                            .SequenceEqual( indexes.Select( i => i.Type ) ) );
-
-                    if ( indexer == null )
-                    {
-                        throw new InvalidOperationException(
-                            $"No matching indexer found on type '{targetExpression.Type}' with parameter types: " +
-                            $"{string.Join( ", ", indexes.Select( i => i.Type.Name ) )}." );
-                    }
-
-                    return Expression.Property( targetExpression, indexer, indexes.ToArray() );
-                }
-
-                return Expression.ArrayAccess( targetExpression, indexes );
+                return resolver.ResolveIndexerExpression( targetExpression, indexes );
             }
         );
     }
@@ -72,78 +52,15 @@ public partial class XsParser
                     )
                 )
             )
-            .Then<Expression>( ( ctx, parts ) =>
+            .Then( ( ctx, parts ) =>
             {
                 var (memberName, (typeArgs, args)) = parts;
 
-                var type = TypeOf( targetExpression );
                 var name = memberName.ToString()!;
 
                 var (_, resolver) = ctx;
-                // method
 
-                if ( args != null )
-                {
-                    var method = resolver.ResolveMethod( type, name, typeArgs, args );
-
-                    if ( method == null )
-                        throw new InvalidOperationException( $"Method '{name}' not found on type '{type}'." );
-
-                    var arguments = GetArgumentsWithDefaults( method, targetExpression, args );
-
-                    return method.IsStatic
-                        ? Expression.Call( method, arguments )
-                        : Expression.Call( targetExpression, method, arguments );
-                }
-
-                // property or field
-
-                var member = resolver.ResolveMember( type, name );
-
-                if ( member == null )
-                    throw new InvalidOperationException( $"Member '{name}' not found on type '{type}'." );
-
-                return member switch
-                {
-                    PropertyInfo property => Expression.Property( targetExpression, property ),
-                    FieldInfo field => Expression.Field( targetExpression, field ),
-                    _ => throw new InvalidOperationException( $"Member '{name}' is not a property or field." )
-                };
+                return resolver.ResolveMemberExpression( targetExpression, name, typeArgs, args );
             } );
-
-        static IReadOnlyList<Expression> GetArgumentsWithDefaults( MethodInfo method, Expression targetExpression, IReadOnlyList<Expression> providedArgs )
-        {
-            var parameters = method.GetParameters();
-            var isExtension = method.IsDefined( typeof( ExtensionAttribute ), false );
-
-            var providedOffset = isExtension ? 1 : 0;
-            var providedCount = providedArgs.Count;
-            var totalParameters = parameters.Length;
-
-            if ( providedCount == totalParameters )
-                return providedArgs;
-
-            var methodArgs = new Expression[totalParameters];
-
-            // add provided arguments
-            if ( isExtension )
-                methodArgs[0] = targetExpression;
-
-            for ( var i = 0; i < providedCount; i++ )
-            {
-                methodArgs[i + providedOffset] = providedArgs[i];
-            }
-
-            // add missing optional parameters
-            for ( var i = providedCount + providedOffset; i < totalParameters; i++ )
-            {
-                methodArgs[i] = parameters[i].HasDefaultValue
-                    ? Expression.Constant( parameters[i].DefaultValue, parameters[i].ParameterType )
-                    : throw new ArgumentException( $"Missing required parameter: {parameters[i].Name}" );
-            }
-
-            return methodArgs;
-        }
     }
 }
-

--- a/src/Hyperbee.XS/XsParser.Members.cs
+++ b/src/Hyperbee.XS/XsParser.Members.cs
@@ -1,6 +1,4 @@
 ﻿using System.Linq.Expressions;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using Hyperbee.XS.Core.Parsers;
 using Parlot.Fluent;
 using static Parlot.Fluent.Parsers;

--- a/src/Hyperbee.XS/XsParser.cs
+++ b/src/Hyperbee.XS/XsParser.cs
@@ -367,18 +367,6 @@ public partial class XsParser
     }
 
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
-    private static Type TypeOf( Expression expression )
-    {
-        ArgumentNullException.ThrowIfNull( expression, nameof( expression ) );
-
-        return expression switch
-        {
-            ConstantExpression ce => ce.Value as Type ?? ce.Type,
-            Expression => expression.Type
-        };
-    }
-
-    [MethodImpl( MethodImplOptions.AggressiveInlining )]
     private static Type CastToType( Expression expression, bool nullable = false )
     {
         if ( expression is not ConstantExpression ce || ce.Value is not Type type )

--- a/test/Hyperbee.XS.Tests/XsParserTests.RawString.cs
+++ b/test/Hyperbee.XS.Tests/XsParserTests.RawString.cs
@@ -1,0 +1,51 @@
+﻿using Hyperbee.XS.Core.Parsers;
+using static System.Linq.Expressions.Expression;
+
+namespace Hyperbee.XS.Tests;
+
+[TestClass]
+public class XsParserRawStringTests
+{
+    public static XsParser Xs { get; set; } = new( TestInitializer.XsConfig );
+
+    [DataTestMethod]
+    [DataRow( CompilerType.Fast )]
+    [DataRow( CompilerType.System )]
+    [DataRow( CompilerType.Interpret )]
+    public void Parse_ShouldSucceed_WithRawStringLiteral( CompilerType compiler )
+    {
+        var expression = Xs.Parse(
+            """"
+            var x = """Raw string with "With Quotes".""";
+            x;
+            """" );
+
+        var lambda = Lambda<Func<string>>( expression );
+
+        var function = lambda.Compile( compiler );
+        var result = function();
+
+        Assert.AreEqual( "Raw string with \"With Quotes\".", result );
+    }
+
+
+    [DataTestMethod]
+    [DataRow( CompilerType.Fast )]
+    [DataRow( CompilerType.System )]
+    [DataRow( CompilerType.Interpret )]
+    public void Parse_ShouldSucceed_WithRawStringWithRawString( CompilerType compiler )
+    {
+        var expression = Xs.Parse(
+            """"""
+            var x = """"Raw string with """With Raw String"""."""";
+            x;
+            """""" );
+
+        var lambda = Lambda<Func<string>>( expression );
+
+        var function = lambda.Compile( compiler );
+        var result = function();
+
+        Assert.AreEqual( """"Raw string with """With Raw String"""."""", result );
+    }
+}


### PR DESCRIPTION
## Description
- Moves member access and indexer resolution logic from the parser to the type resolver.
  This change centralizes these operations within the type resolver.

- Improves the extensibility of the type resolution process by introducing the `ITypeRewriter` and  `ITypeResolver` interfaces
  -  `ITypeResolver` focuses on resolving types and members
  -  `ITypeRewriter` handles the rewriting of expressions, such as indexers and member accesses.
This allows for more flexible customization of how expressions are transformed
during the parsing process.

- Improves error handling and termination parsing
