### PR TITLE
Bump MSTest.TestAdapter to 3.10.1

### DIFF
--- a/test/Hyperbee.XS.Extensions.Tests/Hyperbee.XS.Extensions.Tests.csproj
+++ b/test/Hyperbee.XS.Extensions.Tests/Hyperbee.XS.Extensions.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Hyperbee.XS.Interactive.Tests/Hyperbee.XS.Interactive.Tests.csproj
+++ b/test/Hyperbee.XS.Interactive.Tests/Hyperbee.XS.Interactive.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.DotNet.Interactive.CSharp" Version="1.0.0-beta.25177.1" />
     <PackageReference Include="Microsoft.DotNet.Interactive.Formatting" Version="1.0.0-beta.25177.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Hyperbee.XS.Tests/Hyperbee.XS.Tests.csproj
+++ b/test/Hyperbee.XS.Tests/Hyperbee.XS.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Hyperbee.Expressions" Version="1.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: MSTest.TestAdapter dependency-version: 3.10.1 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: MSTest.TestAdapter dependency-version: 3.10.1 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: MSTest.TestAdapter dependency-version: 3.10.1 dependency-type: direct:production update-type: version-update:semver-minor ...

## Description

_Please include a brief summary of the changes. Mention any related issues or features._
 - `Fixes #<issue_number>_

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

## Checklist

- [ ] I have run the existing tests and they pass
- [ ] I have run the existing benchmarks and verified performance has not decreased
- [ ] I have added new tests that prove my change is effective or that my feature works
- [ ] I have added the necessary documentation (if applicable)
